### PR TITLE
Fix travis config file - build instead of adding QI package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg; pkg"add ."; pkg"add StatsBase"; pkg"add Test"; pkg"test QI --coverage"'
+  - julia -e 'using Pkg; pkg"build QI"; pkg"add StatsBase"; pkg"add Test"; pkg"test QI --coverage"'
   - julia -e 'using Pkg; pkg"add Distributions"';
   - julia --code-coverage randommatrices/test/runtests.jl
 


### PR DESCRIPTION
Thanks to command `export JULIA_PROJECT=@.`, which is by default executed on Julia Travis builds, QI package environment is used as testing environment, therefore `pkg"add ."` fails. 